### PR TITLE
Add --base-url flag for connector testability

### DIFF
--- a/cmd/baton-atlassian/main.go
+++ b/cmd/baton-atlassian/main.go
@@ -59,6 +59,7 @@ func getConnector(ctx context.Context, cfg *config.Atlassian) (types.ConnectorSe
 		cfg.ScimToken,
 		cfg.OrganizationId,
 		cfg.ScimBaseUrl,
+		cfg.BaseUrl,
 	)
 
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -39,6 +39,7 @@ type Config struct {
 	scimToken      string
 	organizationID string
 	scimBaseUrl    string
+	baseURL        string
 }
 
 type Option func(*AtlassianClient)
@@ -67,6 +68,19 @@ func WithOrganizationID(orgID string) Option {
 	}
 }
 
+func WithBaseURL(baseURL string) Option {
+	return func(c *AtlassianClient) {
+		c.config.baseURL = baseURL
+	}
+}
+
+func (c *AtlassianClient) getBaseURL() string {
+	if c.config.baseURL != "" {
+		return c.config.baseURL
+	}
+	return baseURL
+}
+
 // GetOrganizationID returns the organization ID from the client configuration.
 func (c *AtlassianClient) GetOrganizationID() string {
 	return c.config.organizationID
@@ -75,7 +89,7 @@ func (c *AtlassianClient) GetOrganizationID() string {
 // GetOrganization returns the organization details including its name.
 func (c *AtlassianClient) GetOrganization(ctx context.Context) (*Organization, error) {
 	var orgResponse OrganizationResponse
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(organizationEP, c.config.organizationID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(organizationEP, c.config.organizationID))
 	if err != nil {
 		return nil, err
 	}
@@ -96,7 +110,7 @@ func (c *AtlassianClient) GetOrganization(ctx context.Context) (*Organization, e
 // GetGroupMembers returns a list of users that are members of a specific group.
 func (c *AtlassianClient) GetGroupMembers(ctx context.Context, pageToken, groupID string) ([]User, string, error) {
 	var usersResponse UserResponse
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(usersEP, c.config.organizationID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(usersEP, c.config.organizationID))
 	if err != nil {
 		return nil, "", err
 	}
@@ -126,7 +140,7 @@ func (c *AtlassianClient) GetGroupMembers(ctx context.Context, pageToken, groupI
 
 func (c *AtlassianClient) ListUsers(ctx context.Context, pageToken string) ([]User, string, error) {
 	var usersResponse UserResponse
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(usersEP, c.config.organizationID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(usersEP, c.config.organizationID))
 	if err != nil {
 		return nil, "", err
 	}
@@ -153,7 +167,7 @@ func (c *AtlassianClient) ListUsers(ctx context.Context, pageToken string) ([]Us
 
 func (c *AtlassianClient) ListWorkspaces(ctx context.Context, pageToken string) ([]Workspace, string, error) {
 	var workspacesResponse WorkspaceResponse
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(workspacesEP, c.config.organizationID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(workspacesEP, c.config.organizationID))
 	if err != nil {
 		return nil, "", err
 	}
@@ -181,7 +195,7 @@ func (c *AtlassianClient) ListWorkspaces(ctx context.Context, pageToken string) 
 
 func (c *AtlassianClient) ListGroups(ctx context.Context, pageToken string) ([]Group, string, error) {
 	var groupsResponse GroupResponse
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(groupsEP, c.config.organizationID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(groupsEP, c.config.organizationID))
 	if err != nil {
 		return nil, "", err
 	}
@@ -209,7 +223,7 @@ func (c *AtlassianClient) ListGroups(ctx context.Context, pageToken string) ([]G
 func (c *AtlassianClient) GetUserRoleAssignments(ctx context.Context, pageToken, userID string) ([]RoleAssignment, string, error) {
 	var roleAssignmentsResponse RoleAssignmentsResponse
 
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(usersRoleAssignmentEP, c.config.organizationID, userID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(usersRoleAssignmentEP, c.config.organizationID, userID))
 	if err != nil {
 		return nil, "", err
 	}
@@ -236,7 +250,7 @@ func (c *AtlassianClient) GetUserRoleAssignments(ctx context.Context, pageToken,
 func (c *AtlassianClient) GetGroupRoleAssignments(ctx context.Context, pageToken, groupID string) ([]RoleAssignment, string, error) {
 	var roleAssignmentsResponse RoleAssignmentsResponse
 
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(groupsRoleAssignmentEP, c.config.organizationID, groupID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(groupsRoleAssignmentEP, c.config.organizationID, groupID))
 	if err != nil {
 		return nil, "", err
 	}
@@ -266,7 +280,7 @@ func (c *AtlassianClient) AssignRoleToUser(ctx context.Context, userID, workspac
 		Resource: workspaceID,
 	}
 
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(userAssignRolesEP, c.config.organizationID, userID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(userAssignRolesEP, c.config.organizationID, userID))
 	if err != nil {
 		return err
 	}
@@ -290,7 +304,7 @@ func (c *AtlassianClient) RevokeRoleFromUser(ctx context.Context, userID, worksp
 		Resource: workspaceID,
 	}
 
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(userRevokeRolesEP, c.config.organizationID, userID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(userRevokeRolesEP, c.config.organizationID, userID))
 	if err != nil {
 		return err
 	}
@@ -310,7 +324,7 @@ func (c *AtlassianClient) RevokeRoleFromUser(ctx context.Context, userID, worksp
 
 // https://developer.atlassian.com/cloud/admin/organization/rest/api-group-directory/#api-v1-orgs-orgid-directory-users-accountid-suspend-access-post
 func (c *AtlassianClient) DisableUser(ctx context.Context, accountID string) error {
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(userSuspendAccessEP, c.config.organizationID, accountID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(userSuspendAccessEP, c.config.organizationID, accountID))
 	if err != nil {
 		return err
 	}
@@ -330,7 +344,7 @@ func (c *AtlassianClient) DisableUser(ctx context.Context, accountID string) err
 
 // https://developer.atlassian.com/cloud/admin/organization/rest/api-group-directory/#api-v1-orgs-orgid-directory-users-accountid-restore-access-post
 func (c *AtlassianClient) EnableUser(ctx context.Context, accountID string) error {
-	requestURL, err := url.JoinPath(baseURL, fmt.Sprintf(userRestoreAccessEP, c.config.organizationID, accountID))
+	requestURL, err := url.JoinPath(c.getBaseURL(), fmt.Sprintf(userRestoreAccessEP, c.config.organizationID, accountID))
 	if err != nil {
 		return err
 	}

--- a/pkg/config/conf.gen.go
+++ b/pkg/config/conf.gen.go
@@ -8,6 +8,7 @@ type Atlassian struct {
 	OrganizationId string `mapstructure:"organization-id"`
 	ScimToken string `mapstructure:"scim-token"`
 	ScimBaseUrl string `mapstructure:"scim-base-url"`
+	BaseUrl string `mapstructure:"base-url"`
 }
 
 func (c *Atlassian) findFieldByTag(tagValue string) (any, bool) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -36,11 +36,20 @@ var (
 		field.WithDisplayName("SCIM Base URL"),
 	)
 
+	BaseURLField = field.StringField(
+		"base-url",
+		field.WithDisplayName("Base URL"),
+		field.WithDescription("Override the Atlassian Admin API URL (for testing)"),
+		field.WithHidden(true),
+		field.WithExportTarget(field.ExportTargetCLIOnly),
+	)
+
 	ConfigurationFields = []field.SchemaField{
 		AccessTokenField,
 		OrganizationIDField,
 		ScimTokenField,
 		ScimBaseUrlField,
+		BaseURLField,
 	}
 )
 

--- a/pkg/connector/actions.go
+++ b/pkg/connector/actions.go
@@ -13,6 +13,10 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
+const (
+	successKey = "success"
+)
+
 // GlobalActions implements the GlobalActionProvider interface.
 // It registers global actions for the connector.
 func (c *Connector) GlobalActions(ctx context.Context, registry actions.ActionRegistry) error {
@@ -33,7 +37,7 @@ func (c *Connector) GlobalActions(ctx context.Context, registry actions.ActionRe
 		},
 		ReturnTypes: []*config_sdk.Field{
 			{
-				Name:        "success",
+				Name:        successKey,
 				DisplayName: "Success",
 				Field:       &config_sdk.Field_BoolField{},
 			},
@@ -68,7 +72,7 @@ func (c *Connector) GlobalActions(ctx context.Context, registry actions.ActionRe
 		},
 		ReturnTypes: []*config_sdk.Field{
 			{
-				Name:        "success",
+				Name:        successKey,
 				DisplayName: "Success",
 				Field:       &config_sdk.Field_BoolField{},
 			},
@@ -119,7 +123,7 @@ func (c *Connector) handleDisableUser(
 
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"success": structpb.NewBoolValue(true),
+			successKey: structpb.NewBoolValue(true),
 		},
 	}, nil, nil
 }
@@ -153,7 +157,7 @@ func (c *Connector) handleEnableUser(
 
 	return &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"success": structpb.NewBoolValue(true),
+			successKey: structpb.NewBoolValue(true),
 		},
 	}, nil, nil
 }

--- a/pkg/connector/connector.go
+++ b/pkg/connector/connector.go
@@ -102,7 +102,7 @@ func (d *Connector) Validate(_ context.Context) (annotations.Annotations, error)
 }
 
 // New returns a new instance of the connector.
-func New(ctx context.Context, accessToken, scimToken, organizationID, scimBaseUrl string) (*Connector, error) {
+func New(ctx context.Context, accessToken, scimToken, organizationID, scimBaseUrl, baseURL string) (*Connector, error) {
 	l := ctxzap.Extract(ctx)
 
 	clientOpts := []client.Option{
@@ -116,6 +116,10 @@ func New(ctx context.Context, accessToken, scimToken, organizationID, scimBaseUr
 
 	if scimBaseUrl != "" {
 		clientOpts = append(clientOpts, client.WithScimBaseUrl(scimBaseUrl))
+	}
+
+	if baseURL != "" {
+		clientOpts = append(clientOpts, client.WithBaseURL(baseURL))
 	}
 
 	atlassianClient, err := client.New(ctx, clientOpts...)


### PR DESCRIPTION
## Summary

Adds the `--base-url` CLI flag to enable overriding the default API endpoint for testing purposes.

## Changes

- Added `BaseURLField` to configuration
- Updated client/connector to accept and use the base URL override
- When `--base-url` is provided, it takes precedence over the default API URL

## Files Modified

```
cmd/baton-atlassian/main.go,pkg/client/client.go,pkg/config/conf.gen.go,pkg/config/config.go,pkg/connector/connector.go
```

## Testing

The connector can now be tested against mock servers:
```bash
baton-atlassian --base-url http://localhost:8080 [other-flags]
```

## Related

Part of the Connector Testability initiative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable base URL support enabling users to override the default Atlassian Admin API endpoint. A new Base URL configuration option is now available for custom API endpoint URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->