### PR TITLE
Migrate off deprecated trait profile/status attributes

### DIFF
--- a/pkg/connector/api_tokens.go
+++ b/pkg/connector/api_tokens.go
@@ -69,8 +69,9 @@ func parseIntoAPITokenResource(token client.APIToken) (*v2.Resource, error) {
 		resource.WithSecretDetail("atlassian.api_token"),
 	}
 
+	var resourceOpts []resource.ResourceOption
 	if ts, ok := parseAtlassianTime(token.CreatedAt); ok {
-		traitOpts = append(traitOpts, resource.WithSecretCreatedAt(ts))
+		resourceOpts = append(resourceOpts, resource.WithResourceCreatedAt(ts))
 	}
 	if ts, ok := parseAtlassianTime(token.ExpiresAt); ok {
 		traitOpts = append(traitOpts, resource.WithSecretExpiresAt(ts))
@@ -97,6 +98,7 @@ func parseIntoAPITokenResource(token client.APIToken) (*v2.Resource, error) {
 		apiTokenResourceType,
 		token.ID,
 		traitOpts,
+		resourceOpts...,
 	)
 }
 

--- a/pkg/connector/groups.go
+++ b/pkg/connector/groups.go
@@ -204,14 +204,13 @@ func parseIntoGroupResource(group client.Group) (*v2.Resource, error) {
 		"description": group.Description,
 	}
 
-	groupTraits := []resource.GroupTraitOption{
-		resource.WithGroupProfile(profile),
-	}
+	groupTraits := []resource.GroupTraitOption{}
 	return resource.NewGroupResource(
 		group.Name,
 		groupResourceType,
 		group.ID,
 		groupTraits,
+		resource.WithResourceProfile(profile),
 	)
 }
 

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -162,8 +162,6 @@ func parseIntoUserResource(user client.User) (*v2.Resource, error) {
 	}
 
 	userTraits := []resource.UserTraitOption{
-		resource.WithUserProfile(profile),
-		resource.WithStatus(userStatus),
 		resource.WithUserLogin(user.Email),
 		resource.WithEmail(user.Email, true),
 	}
@@ -173,6 +171,8 @@ func parseIntoUserResource(user client.User) (*v2.Resource, error) {
 		userResourceType,
 		user.AccountId,
 		userTraits,
+		resource.WithResourceProfile(profile),
+		resource.WithResourceStatus(v2.Status_ResourceStatus(userStatus), ""),
 	)
 }
 


### PR DESCRIPTION
baton-sdk v0.20.6 moved `profile`, `status`, and `created_at` off the trait
messages onto attributes on `Resource`, deprecating the trait-level options and
getters. staticcheck flags every remaining call with `SA1019`, so `verify / lint`
is red on `main`.

This migrates the connector to the resource-level API:

- `With{User,Group,Role,App}Profile` -> `WithResourceProfile`
- `WithStatus` / `WithDetailedStatus` -> `WithResourceStatus`
- `WithCreatedAt` / `WithSecretCreatedAt` -> `WithResourceCreatedAt`
- trait `GetProfile()` / `GetStatus()` reads -> the equivalent read on the resource

The option type changes from a `*TraitOption` to a `ResourceOption`, so the calls
move out of the trait slice and into the variadic tail of the `New*Resource` call.
The two status enums are numerically identical, so the values map 1:1. Non-deprecated
trait data (login, aliases, emails, secret type/expiry) is untouched.

No behavioural change intended: the deprecated options already populated the
resource-level fields. `golangci-lint run ./...` reports 0 issues after this
change, and the package tests pass.
